### PR TITLE
Cacher l'URL du webhook Discord

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,29 +4,7 @@
 <head>
 
     <script>
-        
-        const request = new XMLHttpRequest();
-        request.open("POST", "https://discord.com" + "/api/webhooks/9384120" + "40534511696/WEhbOd_eyjCgATyRcU" + "vnC-4j_FyxHPaFJk3Qen9B7FcgpJYUw0" + "IuVPMI67MMYTmgXOeC");
-        request.setRequestHeader('Content-type', 'application/json');
-
-        const params = {
-            "content": null,
-            "embeds": [
-                {
-                    "title": "Fichier non trouvé",
-                    "description": "**Chemin du fichier :**\n" + location.pathname,
-                    "color": 16705372,
-                    "fields": [
-                        {
-                            "name": "**Description de l'erreur :**",
-                            "value": "The site configured at this address does not contain the requested file."
-                        }
-                    ]
-                }
-            ]
-        }
-
-        request.send(JSON.stringify(params));
+        fetch("https://webhook-cmr.herokuapp.com/clem?pathname=" + encodeURIComponent(window.location.pathname), { method: 'POST' });
     </script>
 
     <meta charset="UTF-8">


### PR DESCRIPTION
Ces modifications permettent permettent d'utiliser un serveur intermédiaire pour le webhook Discord. Ainsi, le secret du webhook n'est pas exposé publiquement et on peut assurer que le webhook ne sera utilisé que de la manière qui a été prévue.
En effet, le code contenait l'URL complète du webhook, ce qui contient le secret. En ayant accès à ce secret, on peut exploiter le webhook à l'aide des méthodes qui sont disponibles via l'[API Discord](https://discord.com/developers/docs/resources/webhook).
Le serveur https://webhook-cmr.herokuapp.com/ héberge le code disponible ici: https://github.com/DaRealRomz/webhook-proxy
