### PR TITLE
Change webhook URL

### DIFF
--- a/site/index.js
+++ b/site/index.js
@@ -175,31 +175,14 @@ function hideIButton() {
 // UTILITIES
 
 function sendErrorMessage(errorDescription) {
-    const request = new XMLHttpRequest();
-    request.open("POST", "https://discord.com" + "/api/webhooks/9384120" + "40534511696/WEhbOd_eyjCgATyRcU" + "vnC-4j_FyxHPaFJk3Qen9B7FcgpJYUw0" + "IuVPMI67MMYTmgXOeC");
-    request.setRequestHeader('Content-type', 'application/json');
-
-    const params = {
-        "content": null,
-        "embeds": [
-            {
-                "title": "Page WEB non trouvée",
-                "description": "**Chemin de la page :**\n" + location.pathname,
-                "color": 15418782,
-                "fields": [
-                    {
-                        "name": "**Source de la page :**",
-                        "value": getSrc()
-                    },{
-                        "name": "**Description de l'erreur :**",
-                        "value": errorDescription
-                    }
-                ]
-            }
-        ]
-    }
-
-    request.send(JSON.stringify(params));
+    fetch(
+        "https://webhook-cmr.herokuapp.com/jf?pathname=" + encodeURIComponent(window.location.pathname) + "&src=" + encodeURIComponent(getSrc()),
+        {
+            method: "POST",
+            headers: { "Content-Type": "text/plain; charset=utf-8" },
+            body: errorDescription,
+        }
+    );  
 }
 
 function getUrl() {


### PR DESCRIPTION
Ces modifications permettent permettent d'utiliser un serveur intermédiaire pour le webhook Discord. Ainsi, le secret du webhook n'est pas exposé publiquement et on peut assurer que le webhook ne sera utilisé que de la manière qui a été prévue.
En effet, le code contenait l'URL complète du webhook, ce qui contient le secret. En ayant accès à ce secret, on peut exploiter le webhook à l'aide des méthodes qui sont disponibles via l'[API Discord](https://discord.com/developers/docs/resources/webhook).
Le serveur https://webhook-cmr.herokuapp.com/ héberge le code disponible ici: https://github.com/DaRealRomz/webhook-proxy