### PR TITLE
Paramètre différent pour les images

### DIFF
--- a/site/index.js
+++ b/site/index.js
@@ -218,7 +218,7 @@ function populateAnnonces(i) {
     let annoncesDiv = document.getElementById("annonces" + i)
     annonces[i].forEach(annonce => {
         if (isImage(annonce.contenu)) {
-            annoncesDiv.insertAdjacentHTML("beforeend", `<div class="annonce-wrapper"><annonce id=annonce${i} onclick="popupwindow('/site/popup.html?s=${encodeURIComponent(annonce.contenu).replaceAll("'", "\\'")}', 'Babillard', 500, 500);"><img src=${annonce.contenu}></img></annonce></div>`)
+            annoncesDiv.insertAdjacentHTML("beforeend", `<div class="annonce-wrapper"><annonce id=annonce${i} onclick="popupwindow('/site/popup.html?i=${encodeURIComponent(annonce.contenu).replaceAll("'", "\\'")}', 'Babillard', 500, 500);"><img src=${annonce.contenu}></img></annonce></div>`)
         } else {
             annoncesDiv.insertAdjacentHTML("beforeend", `<div class="annonce-wrapper"><annonce id=annonce${i} onclick="popupwindow('/site/popup.html?s=${encodeURIComponent(annonce.contenu).replaceAll("'", "\\'")}', 'Babillard', 500, 500);"><div class="annonce-text"><textarea rows="1" readonly>${annonce.contenu}</textarea></div></annonce></div>`)
             const el = annoncesDiv.lastElementChild.querySelector(".annonce-text textarea");

--- a/site/popup.html
+++ b/site/popup.html
@@ -10,22 +10,16 @@
     <div class="container">
         <div class="text">
             <span id="s"></span>
-            <img id="i"></img>
+            <img id="i" />
         </div>
     </div>
     <script>
-        if (isImage(new URLSearchParams(window.location.search).get("s"))) {
-            document.getElementById("i").src = new URLSearchParams(window.location.search).get("s");
-        } else {
-            document.getElementById("s").innerText = new URLSearchParams(window.location.search).get("s");
-        }
-        
+        const params = new URLSearchParams(window.location.search);
+        document.getElementById("i").src = params.get("i");
+        document.getElementById("s").innerText = params.get("s");
+                
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
             document.body.classList.add("dark");
-        }
-
-        function isImage(url) {
-            return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
         }
     </script>
 </body>


### PR DESCRIPTION
Cette modification permet d'utiliser un paramètre différent pour les images et pour le texte afin d'éviter l'ambigüité.
Elle corrige également l'élément `img` afin que celui-ci n'aie pas de balise fermante, tel que défini dans la [RFC 7992](https://datatracker.ietf.org/doc/html/rfc7992#section-9.5.3) :
> Note: the HTML \<img\> element does not have a closing slash.