### PR TITLE
Chercher tous les commits lors du checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Create directory structure
         run: |
           mkdir dist


### PR DESCRIPTION
Le script qui génère automatiquement le fichier [sitemap.xml](https://collegemont-royal.github.io/sitemap.xml) utilise `git log` pour déterminer la date de la dernière modification. Ce script s'exécute dans une GitHub Action qui prépare les fichiers du site web après un commit sur main.
Cette action utilise [actions/checkout](https://github.com/actions/checkout) pour obtenir le code. Cependant, actions/checkout ne cherche que le dernier commit lors du checkout. Ainsi, tous les fichiers semblent appartenir au même commit et les dates de dernière modification dans le sitemap seront toutes celle du dernier commit. Afin de [chercher l'historique complète](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches), il faut ajouter le paramètre `fetch-depth: 0`. `git log` pourra ainsi déterminer la date réelle de la dernière modification et le sitemap contiendra les bonnes informations.