### PR TITLE
Utiliser un shallow clone pour le build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Puisque le sitemap.xml est désactivé, nous n'avons pas besoin de télécharger l'historique complet de la repo. Ainsi, le build sera plus rapide.